### PR TITLE
Simplify route params handling

### DIFF
--- a/src/app/(default)/articles/[slug]/page.tsx
+++ b/src/app/(default)/articles/[slug]/page.tsx
@@ -6,13 +6,13 @@ import ArticlePageContent from '@/components/pages/ArticlePageContent';
 import { getPathSegmentByLanguage } from '@/lib/localization';
 
 interface ArticlePageProps {
-  params: Promise<{
+  params: {
     slug: string;
-  }>;
+  };
 }
 
 export async function generateMetadata({ params }: ArticlePageProps): Promise<Metadata> {
-  const { slug } = await params;
+  const { slug } = params;
   const article = await getArticleBySlug(slug);
 
   if (!article) {
@@ -93,7 +93,7 @@ export async function generateStaticParams() {
 }
 
 export default async function ArticlePage({ params }: ArticlePageProps) {
-  const { slug } = await params;
+  const { slug } = params;
   const article = await getArticleBySlug(slug);
 
   if (!article) {

--- a/src/app/(default)/meet/all/page.tsx
+++ b/src/app/(default)/meet/all/page.tsx
@@ -11,12 +11,12 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 interface PageProps {
-  params: Promise<{ lang?: string }>;
+  params: { lang?: string };
 }
 
 export default async function Page({ params }: PageProps) {
   // Get language from params, default to English if not provided
-  const { lang = DEFAULT_LANGUAGE } = await params || {};
+  const { lang = DEFAULT_LANGUAGE } = params || {};
 
   return <AllMeetingsPage language={lang} />;
 } 

--- a/src/app/(default)/meet/short/page.tsx
+++ b/src/app/(default)/meet/short/page.tsx
@@ -11,12 +11,12 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 interface PageProps {
-    params: Promise<{ lang?: string }>;
+    params: { lang?: string };
 }
 
 export default async function Page({ params }: PageProps) {
     // Get language from params, default to English if not provided
-    const { lang = DEFAULT_LANGUAGE } = await params || {};
+    const { lang = DEFAULT_LANGUAGE } = params || {};
 
     return <ShortMeetingPage language={lang} />;
 } 

--- a/src/app/(default)/pay/stripe/page.tsx
+++ b/src/app/(default)/pay/stripe/page.tsx
@@ -11,12 +11,12 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 interface PageProps {
-  params: Promise<{ lang?: string }>;
+  params: { lang?: string };
 }
 
 export default async function Page({ params }: PageProps) {
   // Get language from params, default to English if not provided
-  const { lang = DEFAULT_LANGUAGE } = await params || {};
+  const { lang = DEFAULT_LANGUAGE } = params || {};
 
   return <StripePaymentPage language={lang} />;
 } 

--- a/src/app/(i18n)/[lang]/[segment]/[subsegment]/page.tsx
+++ b/src/app/(i18n)/[lang]/[segment]/[subsegment]/page.tsx
@@ -14,11 +14,11 @@ export const revalidate = false;
 export const dynamicParams = false;
 
 interface SubsegmentPageProps {
-    params: Promise<{
+    params: {
         lang: string;
         segment: string;
         subsegment: string;
-    }>;
+    };
 }
 
 // Generate static parameters for all supported languages
@@ -73,7 +73,7 @@ export async function generateStaticParams() {
 
 // Generate metadata based on subsegment
 export async function generateMetadata({ params }: SubsegmentPageProps): Promise<Metadata> {
-    const { lang, segment, subsegment } = await params;
+    const { lang, segment, subsegment } = params;
 
     // Check language validity
     if (!isValidLanguage(lang)) {
@@ -198,7 +198,7 @@ export async function generateMetadata({ params }: SubsegmentPageProps): Promise
 }
 
 export default async function SubsegmentPage({ params }: SubsegmentPageProps) {
-    const { lang, segment, subsegment } = await params;
+    const { lang, segment, subsegment } = params;
 
     // Check if language is valid
     if (!isValidLanguage(lang)) {

--- a/src/app/(i18n)/[lang]/[segment]/page.tsx
+++ b/src/app/(i18n)/[lang]/[segment]/page.tsx
@@ -16,8 +16,8 @@ export const revalidate = false;
 export const dynamicParams = false;
 
 interface SegmentPageProps {
-    params: Promise<{ lang: string; segment: string }>;
-    searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+    params: { lang: string; segment: string };
+    searchParams: { [key: string]: string | string[] | undefined };
 }
 
 // Generate static parameters for all supported languages and segments
@@ -48,8 +48,8 @@ export async function generateStaticParams() {
     return params;
 }
 
-export async function generateMetadata({ params }: { params: Promise<{ lang: string; segment: string }> }): Promise<Metadata> {
-    const { lang, segment } = await params;
+export async function generateMetadata({ params }: { params: { lang: string; segment: string } }): Promise<Metadata> {
+    const { lang, segment } = params;
 
     // Check if language is valid
     if (!isValidLanguage(lang)) {
@@ -93,7 +93,7 @@ export async function generateMetadata({ params }: { params: Promise<{ lang: str
 }
 
 export default async function SegmentPage({ params, searchParams }: SegmentPageProps) {
-    const { lang, segment } = await params;
+    const { lang, segment } = params;
 
     // Check if language is valid
     if (!isValidLanguage(lang)) {
@@ -115,7 +115,7 @@ export default async function SegmentPage({ params, searchParams }: SegmentPageP
             redirect('/pay/');
         } else if (segment === articlesSegment || segment === servicesSegment) {
             // Only access searchParams for articles and services
-            const searchParamsData = await searchParams;
+            const searchParamsData = searchParams;
             const tag = typeof searchParamsData.tag === 'string' ? searchParamsData.tag : undefined;
             const category = typeof searchParamsData.category === 'string' ? searchParamsData.category : undefined;
 

--- a/src/app/(i18n)/[lang]/layout.tsx
+++ b/src/app/(i18n)/[lang]/layout.tsx
@@ -30,9 +30,9 @@ export default async function LocaleLayout({
     params,
 }: {
     children: React.ReactNode;
-    params: Promise<{ lang: string }>;
+    params: { lang: string };
 }) {
-    const { lang } = await params;
+    const { lang } = params;
 
     // Validate language or show 404
     if (!isValidLanguage(lang)) {

--- a/src/app/(i18n)/[lang]/page.tsx
+++ b/src/app/(i18n)/[lang]/page.tsx
@@ -5,9 +5,9 @@ import HomePageContent from '@/components/pages/HomePageContent';
 import { generateHomePageMetadata } from '@/lib/metadata';
 
 interface HomePageProps {
-    params: Promise<{
+    params: {
         lang: string;
-    }>;
+    };
 }
 
 // Generate static params for all supported languages
@@ -16,7 +16,7 @@ export async function generateStaticParams() {
 }
 
 export async function generateMetadata({ params }: HomePageProps): Promise<Metadata> {
-    const { lang } = await params;
+    const { lang } = params;
 
     // Check if language is valid
     if (!isValidLanguage(lang) || lang === DEFAULT_LANGUAGE) {
@@ -27,7 +27,7 @@ export async function generateMetadata({ params }: HomePageProps): Promise<Metad
 }
 
 export default async function LocalizedHomePage({ params }: HomePageProps) {
-    const { lang } = await params;
+    const { lang } = params;
 
     // Check if language is valid
     if (!isValidLanguage(lang)) {

--- a/src/app/api/indexnow/[key]/route.ts
+++ b/src/app/api/indexnow/[key]/route.ts
@@ -20,10 +20,9 @@ export async function generateStaticParams() {
 
 export async function GET(
     request: NextRequest,
-    context: { params: Promise<{ key: string }> }
+    context: { params: { key: string } }
 ): Promise<NextResponse> {
-    // В Next.js 15 параметры являются асинхронными и требуют await
-    const { key } = await context.params;
+    const { key } = context.params;
     const expectedKey = process.env.INDEXNOW_API_KEY;
 
     if (!expectedKey) {


### PR DESCRIPTION
## Summary
- remove `Promise` wrappers from `params` and `searchParams`
- drop `await` when accessing params in route handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857eed76acc833180ce3418ac7f0bec