### PR TITLE
Point genome data to AWS

### DIFF
--- a/scripts/build-genome-circos-data.ts
+++ b/scripts/build-genome-circos-data.ts
@@ -5,12 +5,17 @@
  * computes per-window (1 Mb) SNP density and heterozygosity rate,
  * outputs a compact JSON consumed by the GenomeCircos component.
  *
- * Usage:  npx tsx scripts/build-genome-circos-data.ts
+ * Usage:  npx tsx scripts/build-genome-circos-data.ts [--use-cache]
+ *
+ * By default, downloads SNP data from GENOME_RAW_URL and refreshes the local
+ * cache. Pass --use-cache to read scripts/genome-data/genome_snps.txt when it
+ * exists.
  * Output: public/data/genome-circos.json
  */
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { resolve } from "path";
+import { GENOME_RAW_URL } from "../src/lib/genomeUrls";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -70,7 +75,7 @@ const CHROM_LABEL_MAP: Record<string, string> = {
 
 const ROOT = resolve(__dirname, "..");
 const GENOME_DATA_DIR = resolve(__dirname, "genome-data");
-const SNP_URL = "https://storage.googleapis.com/personal-public-data-km/raw/genome_snps-kirill_markin-atlas_ru-2022_02_22.txt";
+const USE_CACHE_FLAG = "--use-cache";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -87,11 +92,34 @@ const normalizeChrom = (raw: string): string => {
   return `chr${trimmed}`;
 };
 
+type CliOptions = {
+  useCache: boolean;
+};
+
+const parseCliOptions = (args: ReadonlyArray<string>): CliOptions => {
+  let useCache = false;
+
+  for (const arg of args) {
+    if (arg === USE_CACHE_FLAG) {
+      useCache = true;
+      continue;
+    }
+
+    throw new Error(
+      `Unsupported argument: ${arg}. Usage: npx tsx scripts/build-genome-circos-data.ts [${USE_CACHE_FLAG}]`,
+    );
+  }
+
+  return { useCache };
+};
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
 async function main(): Promise<void> {
+  const options = parseCliOptions(process.argv.slice(2));
+
   console.log("=== Building genome Circos data ===");
 
   // 1. Load chromosome sizes
@@ -124,20 +152,27 @@ async function main(): Promise<void> {
     }
   }
 
-  // 3. Download or read cached SNP data
+  // 3. Download SNP data and refresh cache unless cache use is explicit
   const snpCachePath = resolve(GENOME_DATA_DIR, "genome_snps.txt");
   let snpRaw: string;
 
-  if (existsSync(snpCachePath)) {
-    console.log("Reading cached SNP data...");
+  if (options.useCache && existsSync(snpCachePath)) {
+    console.log(`Reading cached SNP data from ${snpCachePath} because ${USE_CACHE_FLAG} was provided.`);
     snpRaw = readFileSync(snpCachePath, "utf-8");
   } else {
-    console.log(`Downloading SNP data from ${SNP_URL}...`);
-    const response = await fetch(SNP_URL);
-    if (!response.ok) {
-      throw new Error(`Failed to download SNP data: ${response.status} ${response.statusText}`);
+    if (options.useCache) {
+      console.log(`Cache requested but missing at ${snpCachePath}; downloading SNP data from ${GENOME_RAW_URL}.`);
+    } else {
+      console.log(`Downloading SNP data from ${GENOME_RAW_URL} and refreshing cache. Pass ${USE_CACHE_FLAG} to read existing cache.`);
     }
-    snpRaw = await response.text();
+    const response = await fetch(GENOME_RAW_URL);
+    const responseBody = await response.text();
+    if (!response.ok) {
+      throw new Error(
+        `Failed to download SNP data: url=${GENOME_RAW_URL} status=${response.status} statusText=${response.statusText} body=${responseBody}`,
+      );
+    }
+    snpRaw = responseBody;
     writeFileSync(snpCachePath, snpRaw);
     console.log(`Cached SNP data to ${snpCachePath}`);
   }

--- a/src/app/(default)/dashboards/body/page.tsx
+++ b/src/app/(default)/dashboards/body/page.tsx
@@ -3,6 +3,7 @@ import { SITE_URL, VCARD_DATA } from '@/data/contacts';
 import { getWeightSeries } from '@/lib/weight';
 import { getWeightCsvMetadata, WEIGHT_CSV_PUBLIC_PATH } from '@/lib/generateWeightCsv';
 import { getGenomeCircosData } from '@/lib/genome';
+import { GENOME_MANIFEST_URL, GENOME_RAW_URL } from '@/lib/genomeUrls';
 import { BodyFacts } from '@/components/charts/BodyFacts';
 import { WeightDashboard } from '@/components/charts/WeightDashboard';
 import { GenomeCircos } from '@/components/charts/GenomeCircos';
@@ -57,7 +58,14 @@ export default async function BodyDashboardPage() {
       subtitle: 'Complete SNP genotyping results from Atlas Biomed (atlas.ru), February 2022. Contains rsID, chromosome, position, and genotype for each variant.',
       format: 'TSV',
       size: '~16 MB',
-      url: 'https://storage.googleapis.com/personal-public-data-km/raw/genome_snps-kirill_markin-atlas_ru-2022_02_22.txt',
+      url: GENOME_RAW_URL,
+    },
+    {
+      title: 'Genome Data Catalog',
+      subtitle: 'Manifest for the public genome dataset, including available files and metadata.',
+      format: 'JSON',
+      size: 'Catalog',
+      url: GENOME_MANIFEST_URL,
     },
   ] as const;
 

--- a/src/lib/genomeUrls.ts
+++ b/src/lib/genomeUrls.ts
@@ -1,0 +1,2 @@
+export const GENOME_MANIFEST_URL = 'https://auto.kirill-markin.com/api/v1/public/personal-data/genome/manifest.json';
+export const GENOME_RAW_URL = 'https://auto.kirill-markin.com/api/v1/public/personal-data/genome/genome-snps-atlas-ru-2022-02-22.txt';

--- a/src/lib/markdownServe.ts
+++ b/src/lib/markdownServe.ts
@@ -6,6 +6,7 @@ import { socialLinks } from '@/data/socialLinks';
 import { bigMediaMentions, smallMediaMentions, type MediaMention } from '@/data/mediaMentions';
 import { getWeightSeries } from '@/lib/weight';
 import { getWeightCsvMetadata, WEIGHT_CSV_PUBLIC_PATH } from '@/lib/generateWeightCsv';
+import { GENOME_MANIFEST_URL, GENOME_RAW_URL } from '@/lib/genomeUrls';
 import type { WeightPoint } from '@/types/weight';
 
 type MarkdownResult = {
@@ -197,7 +198,6 @@ export async function renderMeetMarkdown(language: string): Promise<MarkdownResu
 }
 
 const DEFAULT_RANGE_DAYS = 365;
-const GENOME_URL = 'https://storage.googleapis.com/personal-public-data-km/raw/genome_snps-kirill_markin-atlas_ru-2022_02_22.txt';
 
 const computeAge = (birthDate: string): number => {
   const birth = new Date(birthDate);
@@ -280,7 +280,8 @@ export async function renderDashboardsBodyMarkdown(): Promise<MarkdownResult> {
     `## Raw Data`,
     ``,
     `- [Body Metrics — Weight Series (CSV, ~${csvSizeKb} KB)](${SITE_URL}${WEIGHT_CSV_PUBLIC_PATH}) — ${csvMeta.rowCount} data points, updated daily`,
-    `- [Full Genome — SNP Genotyping Data (TSV, ~16 MB)](${GENOME_URL}) — Atlas Biomed, February 2022`,
+    `- [Full Genome — SNP Genotyping Data (TSV, ~16 MB)](${GENOME_RAW_URL}) — Atlas Biomed, February 2022`,
+    `- [Genome Data Catalog (JSON)](${GENOME_MANIFEST_URL}) — manifest for public genome files and metadata`,
     ``,
     `## Links`,
     ``,


### PR DESCRIPTION
## Summary
- move website genome raw and manifest URLs to AWS endpoints
- update genome circos build script to fetch from AWS by default
- keep local genome cache ignored and explicit

## Validation
- npm run lint
- npm run validate-metadata
- npm run build