### PR TITLE
[codex] rename personal title

### DIFF
--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -16,7 +16,7 @@ export async function GET(): Promise<NextResponse> {
 
     const llmsContent = `# Kirill Markin - AI & Data Engineering Expert
 
-> Personal website of Kirill Markin — CTO, ex-Founder of ozma.io, AI & Data Engineer. Specializes in AI/LLM implementation, data engineering, startup guidance, and technical consulting across multiple languages and industries.
+> Personal website of Kirill Markin — Hands-on Engineering Manager, ex-Founder of ozma.io, AI & Data Engineer. Specializes in AI/LLM implementation, data engineering, startup guidance, and technical consulting across multiple languages and industries.
 
 Kirill Markin is an experienced AI and data engineering professional who helps businesses and individuals leverage artificial intelligence and data technologies. His expertise spans from technical implementation to strategic consulting, with a focus on practical, real-world applications.
 

--- a/src/data/personalInfo.ts
+++ b/src/data/personalInfo.ts
@@ -15,7 +15,7 @@ export const personalInfo: PersonalInfo = {
   email: EMAIL,
   phone: PHONE_NUMBER,
   image: "/avatars/Kirill-Markin.webp",
-  jobTitle: "CTO",
+  jobTitle: "Hands-on Engineering Manager",
   secondaryTitle: "ex-Founder of ozma.io",
   tertiaryTitle: "AI & Data Engineer"
 }; 

--- a/src/data/socialLinks.ts
+++ b/src/data/socialLinks.ts
@@ -34,9 +34,9 @@ export const socialLinks: SocialLink[] = [
     }
   },
   {
-    name: "CV CTO",
+    name: "CV",
     url: "/data/cv-kirill-markin-cto.pdf",
-    username: "CV CTO",
+    username: "CV",
     socialLogoUrlDefault: "/social/cv.svg",
     socialLogoUrlHover: "/social/cv_hover.svg",
     avatarContact: true,

--- a/src/lib/localization/translations/personalInfo.ts
+++ b/src/lib/localization/translations/personalInfo.ts
@@ -1,26 +1,26 @@
 export const personalInfo = {
     en: {
-        jobTitle: 'CTO',
+        jobTitle: 'Hands-on Engineering Manager',
         secondaryTitle: 'ex-Founder of ozma.io',
         tertiaryTitle: 'AI & Data Engineer',
     },
     es: {
-        jobTitle: 'Director de Tecnología',
+        jobTitle: 'Responsable de Ingeniería práctico',
         secondaryTitle: 'Exfundador de ozma.io',
         tertiaryTitle: 'Ingeniero de IA y datos',
     },
     zh: {
-        jobTitle: '首席技术官',
+        jobTitle: '实干型工程经理',
         secondaryTitle: 'ozma.io 前创始人',
         tertiaryTitle: '人工智能与数据工程师',
     },
     ar: {
-        jobTitle: 'المدير التنفيذي للتقنية',
+        jobTitle: 'مدير هندسة عملي',
         secondaryTitle: 'المؤسس السابق لـ ozma.io',
         tertiaryTitle: 'مهندس الذكاء الاصطناعي والبيانات',
     },
     hi: {
-        jobTitle: 'मुख्य तकनीकी अधिकारी',
+        jobTitle: 'व्यावहारिक इंजीनियरिंग प्रबंधक',
         secondaryTitle: 'ozma.io के पूर्व संस्थापक',
         tertiaryTitle: 'एआई और डेटा इंजीनियर',
     },


### PR DESCRIPTION
## Summary
- rename the personal profile title to Hands-on Engineering Manager
- update localized profile title strings and llms.txt
- simplify visible CV label to CV while leaving the PDF URL unchanged

## Validation
- npm run lint
- npm run validate-metadata