### PR TITLE
Stop capturing client console events in Sentry

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -39,7 +39,7 @@ const nextConfig: NextConfig = {
   },
   // Add optimization settings
   compiler: {
-    // Remove console.log/info/debug in production, but keep error/warn for Sentry
+    // Remove noisy console output in production while preserving warnings/errors for browser diagnostics
     removeConsole: process.env.NODE_ENV === 'production' ? {
       exclude: ['error', 'warn'],
     } : false,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -78,13 +78,6 @@ Sentry.init({
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
-  // Capture console.error and console.warn calls
-  integrations: [
-    Sentry.captureConsoleIntegration({
-      levels: ['error', 'warn'],
-    }),
-  ],
-
   // Filter out errors caused by browser extensions
   beforeSend(event) {
     if (isExtensionError(event)) {


### PR DESCRIPTION
## Summary
- remove client-side Sentry console capture integration
- update console stripping comment to reflect browser diagnostics

## Verification
- npm run lint
- npm run build