### PR TITLE
Fix weight chart brush recursion

### DIFF
--- a/src/components/charts/WeightLineChart.tsx
+++ b/src/components/charts/WeightLineChart.tsx
@@ -170,6 +170,7 @@ export const WeightLineChart = (props: Props): ReactElement => {
     const brush = brushX()
       .extent([[margin.left, margin.top], [width - margin.right, height - margin.bottom]])
       .on("end", (event: D3BrushEvent<unknown>) => {
+        if (event.selection === null) return;
         handleBrushEnd(event);
         select(node).call(brush.move, null);
       });


### PR DESCRIPTION
## Summary
- prevent D3 brush clear events from recursively triggering brush end handling

## Verification
- npm run lint
- npm run build
- local browser drag on /dashboards/body/ regular and fullscreen weight charts