### PR TITLE
Set Sentry production environment

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -70,6 +70,8 @@ The following environment variables should be set in your production environment
 |----------|-------------|----------|
 | `NEXT_PUBLIC_SITE_URL` | The full URL of the site | Yes |
 | `NODE_ENV` | Set to "production" for production builds | Yes |
+| `SENTRY_ENVIRONMENT` | Set to "production" for server and edge Sentry events | Yes |
+| `NEXT_PUBLIC_SENTRY_ENVIRONMENT` | Set to "production" for browser Sentry events | Yes |
 
 ## Post-Deployment Checks
 

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -8,6 +8,8 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "https://03518ee8632d2e31dfd1e99510c0723a@o4510646197288960.ingest.de.sentry.io/4510646198272080",
 
+  environment: process.env.SENTRY_ENVIRONMENT,
+
   // Sample 10% of traces in production to stay within free tier limits
   tracesSampleRate: 0.1,
 

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -7,6 +7,8 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: "https://03518ee8632d2e31dfd1e99510c0723a@o4510646197288960.ingest.de.sentry.io/4510646198272080",
 
+  environment: process.env.SENTRY_ENVIRONMENT,
+
   // Sample 10% of traces in production to stay within free tier limits
   tracesSampleRate: 0.1,
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -72,6 +72,8 @@ function isExtensionError(event: Sentry.ErrorEvent): boolean {
 Sentry.init({
   dsn: "https://03518ee8632d2e31dfd1e99510c0723a@o4510646197288960.ingest.de.sentry.io/4510646198272080",
 
+  environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+
   // Sample 10% of traces in production to stay within free tier limits
   tracesSampleRate: 0.1,
 


### PR DESCRIPTION
## Summary
- Configure Sentry server and edge events to use `SENTRY_ENVIRONMENT`.
- Configure browser Sentry events to use `NEXT_PUBLIC_SENTRY_ENVIRONMENT`.
- Document both production env vars in deployment docs.

## Validation
- `git diff --check`
- Vercel production deployment build completed successfully before this commit.