### PR TITLE
[codex] Filter third-party Sentry browser errors

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -120,6 +120,8 @@ export default withSentryConfig(nextConfig, {
   // Only print logs for uploading source maps in CI
   silent: !process.env.CI,
 
+  applicationKey: "kirill-markin-com",
+
   // For all available options, see:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -80,6 +80,14 @@ Sentry.init({
   // Enable logs to be sent to Sentry
   enableLogs: true,
 
+  integrations: (integrations) => [
+    ...integrations,
+    Sentry.thirdPartyErrorFilterIntegration({
+      filterKeys: ['kirill-markin-com'],
+      behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
+    }),
+  ],
+
   // Filter out errors caused by browser extensions
   beforeSend(event) {
     if (isExtensionError(event)) {


### PR DESCRIPTION
## Summary
- Add a Sentry application key at build time.
- Enable Sentry third-party error filtering on the browser client.
- Keep existing browser extension/noise filtering as an additional layer.

## Validation
- npm run lint
- npm run validate-metadata
- npm run build