### PR TITLE
[codex] Tighten Sentry third-party filtering

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -84,7 +84,7 @@ Sentry.init({
     ...integrations,
     Sentry.thirdPartyErrorFilterIntegration({
       filterKeys: ['kirill-markin-com'],
-      behaviour: 'drop-error-if-exclusively-contains-third-party-frames',
+      behaviour: 'drop-error-if-contains-third-party-frames',
     }),
   ],
 


### PR DESCRIPTION
## Summary
- Drop Sentry browser events if they contain third-party stack frames.
- Keep the existing filter key and beforeSend extension filtering unchanged.

## Validation
- npm run lint
- npm run build

Note: npm ci warned local Node v25.6.1 does not match the project engine 24.x, but validation passed.