### PR TITLE
[codex] Fix public genome downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ scripts/genome-data/genome_snps.txt
 
 # Build-generated dashboard exports
 public/data/body-metrics-weight-series.csv
+public/data/genome-manifest.json
+public/data/genome-snps-atlas-ru-2022-02-22.txt

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,17 @@
 import { withSentryConfig } from '@sentry/nextjs';
 import type { NextConfig } from "next";
+import { GENOME_MANIFEST_PUBLIC_PATH, GENOME_RAW_PUBLIC_PATH } from './src/lib/genomeUrls';
+
+const RAW_DATA_HEADERS = [
+  {
+    key: 'Cache-Control',
+    value: 'public, max-age=86400, stale-while-revalidate=604800',
+  },
+  {
+    key: 'X-Robots-Tag',
+    value: 'noindex',
+  },
+];
 
 const nextConfig: NextConfig = {
   // Vercel will handle the deployment - no need for static export
@@ -46,7 +58,28 @@ const nextConfig: NextConfig = {
   },
   // Add SEO headers for non-production
   async headers() {
-    const headers = [];
+    const headers = [
+      {
+        source: '/data/body-metrics-weight-series.csv',
+        headers: RAW_DATA_HEADERS,
+      },
+      {
+        source: GENOME_RAW_PUBLIC_PATH,
+        headers: RAW_DATA_HEADERS,
+      },
+      {
+        source: GENOME_MANIFEST_PUBLIC_PATH,
+        headers: RAW_DATA_HEADERS,
+      },
+      {
+        source: '/data/genome-circos.json',
+        headers: RAW_DATA_HEADERS,
+      },
+      {
+        source: '/data/chatgpt-telegram-bot-telegraf_settings.yaml',
+        headers: RAW_DATA_HEADERS,
+      },
+    ];
 
     // Set X-Robots-Tag: noindex for all non-production environments
     // This ensures custom domains used for preview/staging are also not indexed

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
   "license": "MIT",
   "scripts": {
     "dev": "eslint . && next dev  --turbopack",
-    "build": "npm run generate-weight-data && next build",
+    "build": "npm run generate-public-data && next build",
     "start": "next start",
     "lint": "eslint .",
-    "analyze": "npm run generate-weight-data && ANALYZE=true next build",
-    "vercel-build": "npm run generate-weight-data && next build",
+    "analyze": "npm run generate-public-data && ANALYZE=true next build",
+    "vercel-build": "npm run generate-public-data && next build",
     "validate-metadata": "tsx scripts/validate-metadata.ts",
+    "generate-public-data": "npm run generate-weight-data && npm run generate-genome-public-data",
     "generate-weight-data": "tsx scripts/generate-weight-data.ts",
+    "generate-genome-public-data": "tsx scripts/generate-genome-public-data.ts",
     "test-cache": "tsx scripts/test-cache-headers.ts"
   },
   "dependencies": {

--- a/scripts/build-genome-circos-data.ts
+++ b/scripts/build-genome-circos-data.ts
@@ -7,7 +7,7 @@
  *
  * Usage:  npx tsx scripts/build-genome-circos-data.ts [--use-cache]
  *
- * By default, downloads SNP data from GENOME_RAW_URL and refreshes the local
+ * By default, downloads SNP data from GENOME_RAW_SOURCE_URL and refreshes the local
  * cache. Pass --use-cache to read scripts/genome-data/genome_snps.txt when it
  * exists.
  * Output: public/data/genome-circos.json
@@ -15,7 +15,7 @@
 
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import { resolve } from "path";
-import { GENOME_RAW_URL } from "../src/lib/genomeUrls";
+import { GENOME_RAW_SOURCE_URL } from "../src/lib/genomeUrls";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -161,15 +161,15 @@ async function main(): Promise<void> {
     snpRaw = readFileSync(snpCachePath, "utf-8");
   } else {
     if (options.useCache) {
-      console.log(`Cache requested but missing at ${snpCachePath}; downloading SNP data from ${GENOME_RAW_URL}.`);
+      console.log(`Cache requested but missing at ${snpCachePath}; downloading SNP data from ${GENOME_RAW_SOURCE_URL}.`);
     } else {
-      console.log(`Downloading SNP data from ${GENOME_RAW_URL} and refreshing cache. Pass ${USE_CACHE_FLAG} to read existing cache.`);
+      console.log(`Downloading SNP data from ${GENOME_RAW_SOURCE_URL} and refreshing cache. Pass ${USE_CACHE_FLAG} to read existing cache.`);
     }
-    const response = await fetch(GENOME_RAW_URL);
+    const response = await fetch(GENOME_RAW_SOURCE_URL);
     const responseBody = await response.text();
     if (!response.ok) {
       throw new Error(
-        `Failed to download SNP data: url=${GENOME_RAW_URL} status=${response.status} statusText=${response.statusText} body=${responseBody}`,
+        `Failed to download SNP data: url=${GENOME_RAW_SOURCE_URL} status=${response.status} statusText=${response.statusText} body=${responseBody}`,
       );
     }
     snpRaw = responseBody;

--- a/scripts/generate-genome-public-data.ts
+++ b/scripts/generate-genome-public-data.ts
@@ -1,0 +1,28 @@
+/**
+ * Fetches the public genome artifacts and writes build-local static files.
+ *
+ * Usage: npx tsx scripts/generate-genome-public-data.ts
+ */
+import { generateGenomePublicData } from '../src/lib/generateGenomePublicData';
+
+const main = async (): Promise<void> => {
+  const metadata = await generateGenomePublicData();
+
+  console.log('genome_public_data_generated', {
+    rawOutputPath: metadata.rawOutputPath,
+    manifestOutputPath: metadata.manifestOutputPath,
+    rawFileSizeBytes: metadata.rawFileSizeBytes,
+    manifestFileSizeBytes: metadata.manifestFileSizeBytes,
+    rawSha256: metadata.rawSha256,
+  });
+};
+
+main().catch((error: unknown) => {
+  const errorName = error instanceof Error ? error.name : typeof error;
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  console.error('genome_public_data_generation_failed', {
+    errorName,
+    errorMessage,
+  });
+  process.exitCode = 1;
+});

--- a/src/app/(default)/dashboards/body/page.tsx
+++ b/src/app/(default)/dashboards/body/page.tsx
@@ -3,7 +3,7 @@ import { SITE_URL, VCARD_DATA } from '@/data/contacts';
 import { getWeightSeries } from '@/lib/weight';
 import { getWeightCsvMetadata, WEIGHT_CSV_PUBLIC_PATH } from '@/lib/generateWeightCsv';
 import { getGenomeCircosData } from '@/lib/genome';
-import { GENOME_MANIFEST_URL, GENOME_RAW_URL } from '@/lib/genomeUrls';
+import { GENOME_MANIFEST_PUBLIC_PATH, GENOME_RAW_PUBLIC_PATH } from '@/lib/genomeUrls';
 import { BodyFacts } from '@/components/charts/BodyFacts';
 import { WeightDashboard } from '@/components/charts/WeightDashboard';
 import { GenomeCircos } from '@/components/charts/GenomeCircos';
@@ -66,11 +66,11 @@ export default async function BodyDashboardPage() {
       actions: [
         {
           label: 'Download',
-          url: GENOME_RAW_URL,
+          url: GENOME_RAW_PUBLIC_PATH,
         },
         {
           label: 'Open manifest',
-          url: GENOME_MANIFEST_URL,
+          url: GENOME_MANIFEST_PUBLIC_PATH,
         },
       ],
     },

--- a/src/lib/generateGenomePublicData.ts
+++ b/src/lib/generateGenomePublicData.ts
@@ -1,0 +1,288 @@
+/**
+ * Generates public genome download artifacts at build time.
+ * The raw file and rewritten manifest are written to public/data/ and served statically.
+ */
+import { createHash } from 'crypto';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { SITE_URL } from '@/data/contacts';
+import {
+  GENOME_MANIFEST_PUBLIC_PATH,
+  GENOME_MANIFEST_SOURCE_URL,
+  GENOME_RAW_PUBLIC_PATH,
+  GENOME_RAW_SOURCE_URL,
+} from '@/lib/genomeUrls';
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonObject | readonly JsonValue[];
+
+interface JsonObject {
+  readonly [key: string]: JsonValue;
+}
+
+type GenomeManifest = Readonly<{
+  datasetKey: string;
+  source: string;
+  fileName: string;
+  contentType: string;
+  sizeBytes: number;
+  sha256: string;
+  importedAt: string;
+  publicRawUrl: string;
+}>;
+
+type GenomePublicDataMetadata = Readonly<{
+  rawOutputPath: string;
+  manifestOutputPath: string;
+  rawFileSizeBytes: number;
+  manifestFileSizeBytes: number;
+  rawSha256: string;
+}>;
+
+class GenomePublicDataFetchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GenomePublicDataFetchError';
+  }
+}
+
+class GenomePublicDataValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'GenomePublicDataValidationError';
+  }
+}
+
+const FETCH_ATTEMPTS = 3;
+const FETCH_TIMEOUT_MS = 60_000;
+const FETCH_RETRY_DELAY_MS = 1_000;
+const ERROR_BODY_MAX_LENGTH = 2_000;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/u;
+
+export const GENOME_RAW_OUTPUT_PATH = join(
+  process.cwd(),
+  'public',
+  ...GENOME_RAW_PUBLIC_PATH.split('/').filter(Boolean),
+);
+export const GENOME_MANIFEST_OUTPUT_PATH = join(
+  process.cwd(),
+  'public',
+  ...GENOME_MANIFEST_PUBLIC_PATH.split('/').filter(Boolean),
+);
+
+const getErrorName = (error: unknown): string => {
+  return error instanceof Error ? error.name : typeof error;
+};
+
+const getErrorMessage = (error: unknown): string => {
+  return error instanceof Error ? error.message : String(error);
+};
+
+const toError = (error: unknown, context: string): Error => {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new GenomePublicDataFetchError(`${context}. errorType=${typeof error} errorMessage=${String(error)}`);
+};
+
+const sleep = (milliseconds: number): Promise<void> => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+};
+
+const isJsonObject = (value: JsonValue): value is JsonObject => {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+};
+
+const getStringField = (object: JsonObject, fieldName: string, source: string): string => {
+  const value = object[fieldName];
+
+  if (typeof value !== 'string') {
+    throw new GenomePublicDataValidationError(
+      `Genome manifest field must be a string. source=${source} field=${fieldName} valueType=${typeof value}`,
+    );
+  }
+
+  return value;
+};
+
+const getIntegerField = (object: JsonObject, fieldName: string, source: string): number => {
+  const value = object[fieldName];
+
+  if (typeof value !== 'number' || !Number.isInteger(value)) {
+    throw new GenomePublicDataValidationError(
+      `Genome manifest field must be an integer. source=${source} field=${fieldName} value=${String(value)} valueType=${typeof value}`,
+    );
+  }
+
+  return value;
+};
+
+const parseGenomeManifestPayload = (payload: JsonValue, source: string): GenomeManifest => {
+  if (!isJsonObject(payload)) {
+    throw new GenomePublicDataValidationError(`Genome manifest response must be a JSON object. source=${source}`);
+  }
+
+  const manifest: GenomeManifest = {
+    datasetKey: getStringField(payload, 'datasetKey', source),
+    source: getStringField(payload, 'source', source),
+    fileName: getStringField(payload, 'fileName', source),
+    contentType: getStringField(payload, 'contentType', source),
+    sizeBytes: getIntegerField(payload, 'sizeBytes', source),
+    sha256: getStringField(payload, 'sha256', source),
+    importedAt: getStringField(payload, 'importedAt', source),
+    publicRawUrl: getStringField(payload, 'publicRawUrl', source),
+  };
+
+  if (manifest.sizeBytes <= 0) {
+    throw new GenomePublicDataValidationError(
+      `Genome manifest sizeBytes must be positive. source=${source} sizeBytes=${manifest.sizeBytes}`,
+    );
+  }
+
+  if (!SHA256_PATTERN.test(manifest.sha256)) {
+    throw new GenomePublicDataValidationError(
+      `Genome manifest sha256 is invalid. source=${source} sha256=${manifest.sha256}`,
+    );
+  }
+
+  return manifest;
+};
+
+const parseGenomeManifestJson = (responseBody: Buffer, source: string): GenomeManifest => {
+  const responseText = responseBody.toString('utf-8');
+
+  try {
+    return parseGenomeManifestPayload(JSON.parse(responseText) as JsonValue, source);
+  } catch (error: unknown) {
+    if (error instanceof GenomePublicDataValidationError) {
+      throw error;
+    }
+
+    throw new GenomePublicDataValidationError(
+      `Failed to parse genome manifest JSON. source=${source} body=${responseText} errorName=${getErrorName(error)} errorMessage=${getErrorMessage(error)}`,
+    );
+  }
+};
+
+const fetchBody = async (url: string, accept: string, timeoutMs: number): Promise<Buffer> => {
+  const controller = new AbortController();
+  const timeoutId: ReturnType<typeof setTimeout> = setTimeout(() => {
+    controller.abort();
+  }, timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      headers: {
+        accept,
+      },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      const responseBody = (await response.text()).slice(0, ERROR_BODY_MAX_LENGTH);
+      throw new GenomePublicDataFetchError(
+        `Failed to fetch genome public data. url=${url} status=${response.status} statusText=${response.statusText} body=${responseBody}`,
+      );
+    }
+
+    return Buffer.from(await response.arrayBuffer());
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new GenomePublicDataFetchError(`Timed out fetching genome public data. url=${url} timeoutMs=${timeoutMs}`);
+    }
+
+    throw toError(error, `Failed to fetch genome public data. url=${url} timeoutMs=${timeoutMs}`);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+};
+
+const fetchBodyWithRetries = async (url: string, accept: string): Promise<Buffer> => {
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= FETCH_ATTEMPTS; attempt += 1) {
+    try {
+      return await fetchBody(url, accept, FETCH_TIMEOUT_MS);
+    } catch (error: unknown) {
+      const normalizedError = toError(error, `Failed to fetch genome public data. url=${url}`);
+      lastError = normalizedError;
+
+      if (attempt < FETCH_ATTEMPTS) {
+        const retryDelayMs = FETCH_RETRY_DELAY_MS * attempt;
+        console.warn('genome_public_data_fetch_retry', {
+          url,
+          attempt,
+          maxAttempts: FETCH_ATTEMPTS,
+          retryDelayMs,
+          errorName: normalizedError.name,
+          errorMessage: normalizedError.message,
+        });
+        await sleep(retryDelayMs);
+      }
+    }
+  }
+
+  if (lastError === null) {
+    throw new GenomePublicDataFetchError(
+      `Failed to fetch genome public data. url=${url} attempts=${FETCH_ATTEMPTS}`,
+    );
+  }
+
+  throw lastError;
+};
+
+const getSha256 = (buffer: Buffer): string => {
+  return createHash('sha256').update(buffer).digest('hex');
+};
+
+const validateRawGenome = (rawGenome: Buffer, manifest: GenomeManifest): string => {
+  if (rawGenome.byteLength !== manifest.sizeBytes) {
+    throw new GenomePublicDataValidationError(
+      `Genome raw file size mismatch. url=${GENOME_RAW_SOURCE_URL} actualBytes=${rawGenome.byteLength} expectedBytes=${manifest.sizeBytes}`,
+    );
+  }
+
+  const sha256 = getSha256(rawGenome);
+  if (sha256 !== manifest.sha256) {
+    throw new GenomePublicDataValidationError(
+      `Genome raw file sha256 mismatch. url=${GENOME_RAW_SOURCE_URL} actualSha256=${sha256} expectedSha256=${manifest.sha256}`,
+    );
+  }
+
+  return sha256;
+};
+
+const rewriteManifest = (manifest: GenomeManifest): GenomeManifest => {
+  return {
+    ...manifest,
+    publicRawUrl: `${SITE_URL}${GENOME_RAW_PUBLIC_PATH}`,
+  };
+};
+
+const serializeManifest = (manifest: GenomeManifest): string => {
+  return `${JSON.stringify(manifest, null, 2)}\n`;
+};
+
+export const generateGenomePublicData = async (): Promise<GenomePublicDataMetadata> => {
+  const manifestBody = await fetchBodyWithRetries(GENOME_MANIFEST_SOURCE_URL, 'application/json');
+  const manifest = parseGenomeManifestJson(manifestBody, GENOME_MANIFEST_SOURCE_URL);
+  const rawGenome = await fetchBodyWithRetries(GENOME_RAW_SOURCE_URL, manifest.contentType);
+  const rawSha256 = validateRawGenome(rawGenome, manifest);
+  const rewrittenManifest = serializeManifest(rewriteManifest(manifest));
+
+  mkdirSync(dirname(GENOME_RAW_OUTPUT_PATH), { recursive: true });
+  writeFileSync(GENOME_RAW_OUTPUT_PATH, rawGenome);
+  writeFileSync(GENOME_MANIFEST_OUTPUT_PATH, rewrittenManifest, 'utf-8');
+
+  return {
+    rawOutputPath: GENOME_RAW_OUTPUT_PATH,
+    manifestOutputPath: GENOME_MANIFEST_OUTPUT_PATH,
+    rawFileSizeBytes: rawGenome.byteLength,
+    manifestFileSizeBytes: Buffer.byteLength(rewrittenManifest, 'utf-8'),
+    rawSha256,
+  };
+};

--- a/src/lib/genomeUrls.ts
+++ b/src/lib/genomeUrls.ts
@@ -1,2 +1,5 @@
-export const GENOME_MANIFEST_URL = 'https://auto.kirill-markin.com/api/v1/public/personal-data/genome/manifest.json';
-export const GENOME_RAW_URL = 'https://auto.kirill-markin.com/api/v1/public/personal-data/genome/genome-snps-atlas-ru-2022-02-22.txt';
+export const GENOME_MANIFEST_PUBLIC_PATH = '/data/genome-manifest.json';
+export const GENOME_RAW_PUBLIC_PATH = '/data/genome-snps-atlas-ru-2022-02-22.txt';
+
+export const GENOME_MANIFEST_SOURCE_URL = 'https://auto.kirill-markin.com/api/v1/public/personal-data/genome/manifest.json';
+export const GENOME_RAW_SOURCE_URL = 'https://auto.kirill-markin.com/api/v1/public/personal-data/genome/genome-snps-atlas-ru-2022-02-22.txt';

--- a/src/lib/markdownServe.ts
+++ b/src/lib/markdownServe.ts
@@ -6,7 +6,7 @@ import { socialLinks } from '@/data/socialLinks';
 import { bigMediaMentions, smallMediaMentions, type MediaMention } from '@/data/mediaMentions';
 import { getWeightSeries } from '@/lib/weight';
 import { getWeightCsvMetadata, WEIGHT_CSV_PUBLIC_PATH } from '@/lib/generateWeightCsv';
-import { GENOME_MANIFEST_URL, GENOME_RAW_URL } from '@/lib/genomeUrls';
+import { GENOME_MANIFEST_PUBLIC_PATH, GENOME_RAW_PUBLIC_PATH } from '@/lib/genomeUrls';
 import type { WeightPoint } from '@/types/weight';
 
 type MarkdownResult = {
@@ -280,7 +280,7 @@ export async function renderDashboardsBodyMarkdown(): Promise<MarkdownResult> {
     `## Raw Data`,
     ``,
     `- [Body Metrics — Weight Series (CSV, ~${csvSizeKb} KB)](${SITE_URL}${WEIGHT_CSV_PUBLIC_PATH}) — ${csvMeta.rowCount} data points, updated daily`,
-    `- [Full Genome — SNP Genotyping Data (TSV, ~16 MB)](${GENOME_RAW_URL}) — Atlas Biomed, February 2022; [manifest JSON](${GENOME_MANIFEST_URL})`,
+    `- [Full Genome — SNP Genotyping Data (TSV, ~16 MB)](${SITE_URL}${GENOME_RAW_PUBLIC_PATH}) — Atlas Biomed, February 2022; [manifest JSON](${SITE_URL}${GENOME_MANIFEST_PUBLIC_PATH})`,
     ``,
     `## Links`,
     ``,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,6 +6,42 @@ import type { NextRequest } from 'next/server';
 const KNOWN_PAGE_NAMES: Set<string> = new Set(
     Object.values(PATH_SEGMENTS).flatMap(locales => Object.values(locales))
 );
+const PUBLIC_ASSET_PATH_PREFIXES: ReadonlyArray<string> = [
+    '/api/',
+    '/data/',
+    '/articles/assets/',
+    '/samo-danni-eood/',
+];
+const FILE_EXTENSION_PATTERN = /\/[^/]+\.[^/]+$/u;
+const MARKDOWN_EXTENSION_PATTERN = /\.(?:md|txt)$/u;
+
+const hasFileExtension = (pathname: string): boolean => {
+    return FILE_EXTENSION_PATTERN.test(pathname);
+};
+
+const hasMarkdownExtension = (pathname: string): boolean => {
+    return MARKDOWN_EXTENSION_PATTERN.test(pathname);
+};
+
+const isPublicAssetPath = (pathname: string): boolean => {
+    return PUBLIC_ASSET_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+};
+
+const shouldBypassProxy = (pathname: string): boolean => {
+    if (pathname === '/llms.txt' || pathname === '/robots.txt') {
+        return true;
+    }
+
+    if (isPublicAssetPath(pathname)) {
+        return true;
+    }
+
+    return hasFileExtension(pathname) && !hasMarkdownExtension(pathname);
+};
+
+const shouldAdvertiseMarkdown = (pathname: string): boolean => {
+    return !shouldBypassProxy(pathname) && !hasFileExtension(pathname);
+};
 
 export function proxy(request: NextRequest) {
     const { pathname } = request.nextUrl;
@@ -16,13 +52,12 @@ export function proxy(request: NextRequest) {
         return NextResponse.redirect(redirectUrl, 308);
     }
 
+    if (shouldBypassProxy(pathname)) {
+        return NextResponse.next();
+    }
+
     // --- Markdown serving: .md / .txt extension ---
     if (pathname.endsWith('.md') || pathname.endsWith('.txt')) {
-        // Exclude /llms.txt and /robots.txt — they have their own handlers
-        if (pathname === '/llms.txt' || pathname === '/robots.txt') {
-            return NextResponse.next();
-        }
-
         const ext = pathname.endsWith('.md') ? '.md' : '.txt';
         const stripped = pathname.slice(1, -ext.length); // remove leading / and extension
 
@@ -48,6 +83,7 @@ export function proxy(request: NextRequest) {
     const accept = request.headers.get('accept') || '';
     if (
         accept.includes('text/markdown') &&
+        shouldAdvertiseMarkdown(pathname) &&
         !pathname.startsWith('/api/') &&
         !pathname.startsWith('/_next/')
     ) {
@@ -70,10 +106,12 @@ export function proxy(request: NextRequest) {
     response.headers.set('x-language', lang);
     response.headers.set('Vary', 'Accept');
 
-    // Advertise Markdown alternate via standard Link header
-    const cleanPath = pathname.replace(/\/+$/, '');
-    const mdPath = cleanPath === '' ? '/.md' : `${cleanPath}.md`;
-    response.headers.set('Link', `<${mdPath}>; rel="alternate"; type="text/markdown"`);
+    if (shouldAdvertiseMarkdown(pathname)) {
+        // Advertise Markdown alternate via standard Link header
+        const cleanPath = pathname.replace(/\/+$/, '');
+        const mdPath = cleanPath === '' ? '/.md' : `${cleanPath}.md`;
+        response.headers.set('Link', `<${mdPath}>; rel="alternate"; type="text/markdown"`);
+    }
 
     return response;
 }


### PR DESCRIPTION
## Summary

- Generate public genome download artifacts at build time under `public/data` instead of exposing expiring upstream URLs.
- Keep public links stable on the site while preserving upstream URLs for build-time scripts.
- Prevent Markdown alternate headers from being attached to non-page files and add explicit raw-data cache/noindex headers.

## Validation

- `npm run lint`
- `npm run build`
- `npm run validate-metadata`
- Local curl checks for genome TXT, range requests, manifest JSON, dashboard links, Markdown pages, and file endpoints

Note: `npx tsx scripts/test-cache-headers.ts` hit unrelated production request timeouts while successful responses showed the expected cache headers.