### PR TITLE
Update mentorship Lite and Standard plan prices

### DIFF
--- a/src/data/servicesMentorship.ts
+++ b/src/data/servicesMentorship.ts
@@ -26,7 +26,7 @@ export const servicesMentorshipData: ServiceFractionalCTOData = {
         {
             planId: 'lite',
             name: 'Lite',
-            price: '$150/month',
+            price: '$250/month',
             hours: '1 call + async chat',
             features: [
                 '1 call per month (60min/call)',
@@ -43,7 +43,7 @@ export const servicesMentorshipData: ServiceFractionalCTOData = {
         {
             planId: 'standard',
             name: 'Standard',
-            price: '$300/month',
+            price: '$400/month',
             hours: '2 calls + priority async',
             features: [
                 'Everything in Lite plan',


### PR DESCRIPTION
Updates the published mentorship tariffs in `src/data/servicesMentorship.ts` (page `/services/mentorship/`).

- **Lite:** $150/month -> $250/month
- **Standard:** $300/month -> $400/month

Premium and all other plans (Fractional CTO, etc.) are unchanged. Meeting cadence (1 call/month for Lite, 2 calls/month for Standard) is unchanged — only the price differs. Prices are not duplicated elsewhere (no hardcoded prose prices, single source across all languages). `npm run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)