### PR TITLE
[codex] Minimize global LLM rules block

### DIFF
--- a/src/content/articles/claude-code-rules-for-ai.md
+++ b/src/content/articles/claude-code-rules-for-ai.md
@@ -57,12 +57,10 @@ This block is boring on purpose. Good rules usually are. I am not trying to desc
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -70,27 +68,16 @@ This block is boring on purpose. Good rules usually are. I am not trying to desc
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -107,18 +94,14 @@ This block is boring on purpose. Good rules usually are. I am not trying to desc
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/codex-rules-for-ai.md
+++ b/src/content/articles/codex-rules-for-ai.md
@@ -65,12 +65,10 @@ This is the baseline I want Codex to bring into any repository before it sees pr
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -78,27 +76,16 @@ This is the baseline I want Codex to bring into any repository before it sees pr
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -115,18 +102,14 @@ This is the baseline I want Codex to bring into any repository before it sees pr
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/cursor-ide-rules-for-ai.md
+++ b/src/content/articles/cursor-ide-rules-for-ai.md
@@ -46,12 +46,10 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -59,27 +57,16 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -96,18 +83,14 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/ar/qawaid-claude-code-lilthakaa-alistinaei.md
+++ b/src/content/articles/translations/ar/qawaid-claude-code-lilthakaa-alistinaei.md
@@ -60,12 +60,10 @@ translations:
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -73,27 +71,16 @@ translations:
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -110,18 +97,14 @@ translations:
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/ar/qawaid-codex-lilthakaa-alistinaei.md
+++ b/src/content/articles/translations/ar/qawaid-codex-lilthakaa-alistinaei.md
@@ -68,12 +68,10 @@ translations:
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -81,27 +79,16 @@ translations:
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -118,18 +105,14 @@ translations:
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/ar/qawaid-cursor-ide-lilthakaa-alistinaei-tahseen-barmaja.md
+++ b/src/content/articles/translations/ar/qawaid-cursor-ide-lilthakaa-alistinaei-tahseen-barmaja.md
@@ -59,12 +59,10 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -72,27 +70,16 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -109,18 +96,14 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/es/reglas-claude-code-para-ia.md
+++ b/src/content/articles/translations/es/reglas-claude-code-para-ia.md
@@ -62,12 +62,10 @@ Lo mantengo en inglés porque es el contenido literal de mi `~/.claude/CLAUDE.md
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -75,27 +73,16 @@ Lo mantengo en inglés porque es el contenido literal de mi `~/.claude/CLAUDE.md
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -112,18 +99,14 @@ Lo mantengo en inglés porque es el contenido literal de mi `~/.claude/CLAUDE.md
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/es/reglas-codex-para-ia.md
+++ b/src/content/articles/translations/es/reglas-codex-para-ia.md
@@ -70,12 +70,10 @@ Lo dejo en inglés porque es el contenido literal de mi `AGENTS.md` personal y e
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -83,27 +81,16 @@ Lo dejo en inglés porque es el contenido literal de mi `AGENTS.md` personal y e
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -120,18 +107,14 @@ Lo dejo en inglés porque es el contenido literal de mi `AGENTS.md` personal y e
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/es/reglas-cursor-ide-para-ia.md
+++ b/src/content/articles/translations/es/reglas-cursor-ide-para-ia.md
@@ -52,12 +52,10 @@ Yo pego este bloque tal cual en Cursor. Lo dejo en inglés porque está pensado 
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -65,27 +63,16 @@ Yo pego este bloque tal cual en Cursor. Lo dejo en inglés porque está pensado 
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -102,18 +89,14 @@ Yo pego este bloque tal cual en Cursor. Lo dejo en inglés porque está pensado 
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/hi/claude-code-niyam-kritrim-buddhimatta-ke-liye.md
+++ b/src/content/articles/translations/hi/claude-code-niyam-kritrim-buddhimatta-ke-liye.md
@@ -60,12 +60,10 @@ Anthropic के [Claude Code docs](https://docs.anthropic.com/en/docs/claude-co
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -73,27 +71,16 @@ Anthropic के [Claude Code docs](https://docs.anthropic.com/en/docs/claude-co
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -110,18 +97,14 @@ Anthropic के [Claude Code docs](https://docs.anthropic.com/en/docs/claude-co
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/hi/codex-niyam-kritrim-buddhimatta-ke-liye.md
+++ b/src/content/articles/translations/hi/codex-niyam-kritrim-buddhimatta-ke-liye.md
@@ -68,12 +68,10 @@ OpenAI के [Codex docs](https://developers.openai.com/codex/) कहते �
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -81,27 +79,16 @@ OpenAI के [Codex docs](https://developers.openai.com/codex/) कहते �
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -118,18 +105,14 @@ OpenAI के [Codex docs](https://developers.openai.com/codex/) कहते �
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/hi/cursor-ide-niyam-kritrim-buddhimatta-coding-ke-liye.md
+++ b/src/content/articles/translations/hi/cursor-ide-niyam-kritrim-buddhimatta-coding-ke-liye.md
@@ -62,12 +62,10 @@ Cursor में यह रास्ता अपनाएं: `Settings` -> `Cu
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -75,27 +73,16 @@ Cursor में यह रास्ता अपनाएं: `Settings` -> `Cu
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -112,18 +99,14 @@ Cursor में यह रास्ता अपनाएं: `Settings` -> `Cu
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/zh/claude-code-ai-guize.md
+++ b/src/content/articles/translations/zh/claude-code-ai-guize.md
@@ -59,12 +59,10 @@ Anthropic 的 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-cod
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -72,27 +70,16 @@ Anthropic 的 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-cod
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -109,18 +96,14 @@ Anthropic 的 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-cod
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/zh/codex-ai-guize.md
+++ b/src/content/articles/translations/zh/codex-ai-guize.md
@@ -67,12 +67,10 @@ OpenAI 的 [Codex 文档](https://developers.openai.com/codex/)说明，Codex �
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -80,27 +78,16 @@ OpenAI 的 [Codex 文档](https://developers.openai.com/codex/)说明，Codex �
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -117,18 +104,14 @@ OpenAI 的 [Codex 文档](https://developers.openai.com/codex/)说明，Codex �
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation

--- a/src/content/articles/translations/zh/cursor-ide-ai-bianma-guize-youhua.md
+++ b/src/content/articles/translations/zh/cursor-ide-ai-bianma-guize-youhua.md
@@ -51,12 +51,10 @@ Cursor IDE 现在有三层规则：
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Use strict typing everywhere - function returns, variables, collections
+- Prefer simple solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
 - Check if logic already exists before writing new code
-- Avoid untyped variables and generic types
 - Never use default parameter values - make all parameters explicit
-- Create proper type definitions for complex data structures
-- All imports at the top of the file
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
 
 ## Error Handling
@@ -64,27 +62,16 @@ Cursor IDE 现在有三层规则：
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- Error messages should be clear and actionable
-- No fallbacks unless I explicitly ask for them; code should either succeed or fail with a clear error
-- Transparent debugging: when something fails, show exactly what went wrong and why
-- Fix root causes, not symptoms; fallbacks hide real problems that need solving
+- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
-- Error messages must include enough context to debug: request params, response body, status codes; no generic "something went wrong"
+- Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
-
-## Language Specifics
-
-- Prefer structured data models over loose dictionaries, such as Pydantic models or typed interfaces
-- Avoid generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
-- Use modern package management files like `pyproject.toml` and `package.json`
-- Use the language's strict type features when available, such as discriminated unions and enums
 
 ## Libraries and Dependencies
 
-- Install dependencies in project environments, not globally
-- Add dependencies to project config files, not as one-off manual installs
+- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
-- Update project configuration files when adding dependencies
 
 ## Testing
 
@@ -101,18 +88,14 @@ Cursor IDE 现在有三层规则：
 
 - Prefer non-interactive commands with flags over interactive ones
 - Always use non-interactive git diff: `git --no-pager diff` or `git diff | cat`
-- Prefer `rg` for searching code and files
 
 ## Workflow
 
 - Read the existing code and relevant project instructions before editing
-- Keep changes minimal and related to the current request
+- Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
-- Suggest only minimal changes related to the current dialog
-- Change as few lines as possible while solving the problem
-- Focus only on what the user is asking for; no extra improvements
 - When project instructions include test or lint commands, run them before finishing if the task changed code
 
 ## Documentation


### PR DESCRIPTION
## What changed

- Minimized the reusable global LLM rules code block across Cursor, Claude Code, and Codex articles in every language.
- Merged repeated workflow, fallback/root-cause, error-message, typing, and dependency guidance into fewer bullets without changing the intended rules.
- Removed the `rg` preference and imports-at-top bullet from the public reusable block.
- Kept all 15 copies byte-identical.

## Validation

- Passed: `git --no-pager diff --check`.
- Passed: local hash check found 15 blocks with 1 unique SHA-256 hash.
- Blocked: `npm run validate-metadata` failed because dependencies are not installed (`Cannot find module chalk`).
- Not retried: `npm ci` previously failed in this worktree because the local disk ran out of space (`ENOSPC`).

## Notes

This PR only applies the approved minimization of the existing block; it does not add the next batch of new rule ideas.