### PR TITLE
[codex] Add global LLM rules guidance

### DIFF
--- a/src/content/articles/claude-code-rules-for-ai.md
+++ b/src/content/articles/claude-code-rules-for-ai.md
@@ -57,8 +57,8 @@ This block is boring on purpose. Good rules usually are. I am not trying to desc
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -68,27 +68,24 @@ This block is boring on purpose. Good rules usually are. I am not trying to desc
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -100,6 +97,7 @@ This block is boring on purpose. Good rules usually are. I am not trying to desc
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -107,7 +105,7 @@ This block is boring on purpose. Good rules usually are. I am not trying to desc
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/codex-rules-for-ai.md
+++ b/src/content/articles/codex-rules-for-ai.md
@@ -65,8 +65,8 @@ This is the baseline I want Codex to bring into any repository before it sees pr
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -76,27 +76,24 @@ This is the baseline I want Codex to bring into any repository before it sees pr
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -108,6 +105,7 @@ This is the baseline I want Codex to bring into any repository before it sees pr
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -115,7 +113,7 @@ This is the baseline I want Codex to bring into any repository before it sees pr
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/cursor-ide-rules-for-ai.md
+++ b/src/content/articles/cursor-ide-rules-for-ai.md
@@ -46,8 +46,8 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -57,27 +57,24 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -89,6 +86,7 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -96,7 +94,7 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/ar/qawaid-claude-code-lilthakaa-alistinaei.md
+++ b/src/content/articles/translations/ar/qawaid-claude-code-lilthakaa-alistinaei.md
@@ -60,8 +60,8 @@ translations:
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -71,27 +71,24 @@ translations:
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -103,6 +100,7 @@ translations:
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -110,7 +108,7 @@ translations:
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/ar/qawaid-codex-lilthakaa-alistinaei.md
+++ b/src/content/articles/translations/ar/qawaid-codex-lilthakaa-alistinaei.md
@@ -68,8 +68,8 @@ translations:
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -79,27 +79,24 @@ translations:
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -111,6 +108,7 @@ translations:
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -118,7 +116,7 @@ translations:
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/ar/qawaid-cursor-ide-lilthakaa-alistinaei-tahseen-barmaja.md
+++ b/src/content/articles/translations/ar/qawaid-cursor-ide-lilthakaa-alistinaei-tahseen-barmaja.md
@@ -59,8 +59,8 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -70,27 +70,24 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -102,6 +99,7 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -109,7 +107,7 @@ Cursor -> Settings -> Cursor Settings -> Rules for AI:
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/es/reglas-claude-code-para-ia.md
+++ b/src/content/articles/translations/es/reglas-claude-code-para-ia.md
@@ -62,8 +62,8 @@ Lo mantengo en inglés porque es el contenido literal de mi `~/.claude/CLAUDE.md
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -73,27 +73,24 @@ Lo mantengo en inglés porque es el contenido literal de mi `~/.claude/CLAUDE.md
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -105,6 +102,7 @@ Lo mantengo en inglés porque es el contenido literal de mi `~/.claude/CLAUDE.md
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -112,7 +110,7 @@ Lo mantengo en inglés porque es el contenido literal de mi `~/.claude/CLAUDE.md
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/es/reglas-codex-para-ia.md
+++ b/src/content/articles/translations/es/reglas-codex-para-ia.md
@@ -70,8 +70,8 @@ Lo dejo en inglés porque es el contenido literal de mi `AGENTS.md` personal y e
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -81,27 +81,24 @@ Lo dejo en inglés porque es el contenido literal de mi `AGENTS.md` personal y e
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -113,6 +110,7 @@ Lo dejo en inglés porque es el contenido literal de mi `AGENTS.md` personal y e
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -120,7 +118,7 @@ Lo dejo en inglés porque es el contenido literal de mi `AGENTS.md` personal y e
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/es/reglas-cursor-ide-para-ia.md
+++ b/src/content/articles/translations/es/reglas-cursor-ide-para-ia.md
@@ -52,8 +52,8 @@ Yo pego este bloque tal cual en Cursor. Lo dejo en inglés porque está pensado 
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -63,27 +63,24 @@ Yo pego este bloque tal cual en Cursor. Lo dejo en inglés porque está pensado 
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -95,6 +92,7 @@ Yo pego este bloque tal cual en Cursor. Lo dejo en inglés porque está pensado 
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -102,7 +100,7 @@ Yo pego este bloque tal cual en Cursor. Lo dejo en inglés porque está pensado 
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/hi/claude-code-niyam-kritrim-buddhimatta-ke-liye.md
+++ b/src/content/articles/translations/hi/claude-code-niyam-kritrim-buddhimatta-ke-liye.md
@@ -60,8 +60,8 @@ Anthropic के [Claude Code docs](https://docs.anthropic.com/en/docs/claude-co
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -71,27 +71,24 @@ Anthropic के [Claude Code docs](https://docs.anthropic.com/en/docs/claude-co
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -103,6 +100,7 @@ Anthropic के [Claude Code docs](https://docs.anthropic.com/en/docs/claude-co
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -110,7 +108,7 @@ Anthropic के [Claude Code docs](https://docs.anthropic.com/en/docs/claude-co
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/hi/codex-niyam-kritrim-buddhimatta-ke-liye.md
+++ b/src/content/articles/translations/hi/codex-niyam-kritrim-buddhimatta-ke-liye.md
@@ -68,8 +68,8 @@ OpenAI के [Codex docs](https://developers.openai.com/codex/) कहते �
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -79,27 +79,24 @@ OpenAI के [Codex docs](https://developers.openai.com/codex/) कहते �
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -111,6 +108,7 @@ OpenAI के [Codex docs](https://developers.openai.com/codex/) कहते �
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -118,7 +116,7 @@ OpenAI के [Codex docs](https://developers.openai.com/codex/) कहते �
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/hi/cursor-ide-niyam-kritrim-buddhimatta-coding-ke-liye.md
+++ b/src/content/articles/translations/hi/cursor-ide-niyam-kritrim-buddhimatta-coding-ke-liye.md
@@ -62,8 +62,8 @@ Cursor में यह रास्ता अपनाएं: `Settings` -> `Cu
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -73,27 +73,24 @@ Cursor में यह रास्ता अपनाएं: `Settings` -> `Cu
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -105,6 +102,7 @@ Cursor में यह रास्ता अपनाएं: `Settings` -> `Cu
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -112,7 +110,7 @@ Cursor में यह रास्ता अपनाएं: `Settings` -> `Cu
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/zh/claude-code-ai-guize.md
+++ b/src/content/articles/translations/zh/claude-code-ai-guize.md
@@ -59,8 +59,8 @@ Anthropic 的 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-cod
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -70,27 +70,24 @@ Anthropic 的 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-cod
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -102,6 +99,7 @@ Anthropic 的 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-cod
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -109,7 +107,7 @@ Anthropic 的 [Claude Code 文档](https://docs.anthropic.com/en/docs/claude-cod
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/zh/codex-ai-guize.md
+++ b/src/content/articles/translations/zh/codex-ai-guize.md
@@ -67,8 +67,8 @@ OpenAI 的 [Codex 文档](https://developers.openai.com/codex/)说明，Codex �
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -78,27 +78,24 @@ OpenAI 的 [Codex 文档](https://developers.openai.com/codex/)说明，Codex �
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -110,6 +107,7 @@ OpenAI 的 [Codex 文档](https://developers.openai.com/codex/)说明，Codex �
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -117,7 +115,7 @@ OpenAI 的 [Codex 文档](https://developers.openai.com/codex/)说明，Codex �
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications

--- a/src/content/articles/translations/zh/cursor-ide-ai-bianma-guize-youhua.md
+++ b/src/content/articles/translations/zh/cursor-ide-ai-bianma-guize-youhua.md
@@ -51,8 +51,8 @@ Cursor IDE 现在有三层规则：
 - Use OOP classes only for connectors and interfaces to external systems
 - Write pure functions - only modify return values, never input parameters or global state
 - Follow DRY, KISS, and YAGNI principles
-- Prefer simple solutions and avoid premature abstractions
-- Use strict typing for returns, variables, collections, and complex data; prefer structured models or typed interfaces over loose dictionaries; avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`; use strict language features such as discriminated unions and enums
+- Prefer simple, native, vendor-recommended solutions and avoid premature abstractions
+- Use strict typing for returns, variables, collections, and complex data; validate external/API data at runtime; require needed fields, ignore unrelated extra fields, prefer structured models over loose dictionaries, and avoid weak generic types like `Any`, `unknown`, or `List[Dict[str, Any]]`
 - Check if logic already exists before writing new code
 - Never use default parameter values - make all parameters explicit
 - Write simple single-purpose functions - no multi-mode behavior, no flag parameters that switch logic. If the user needs multiple modes, they will ask explicitly
@@ -62,27 +62,24 @@ Cursor IDE 现在有三层规则：
 - Always raise errors explicitly, never silently ignore them
 - Use specific error types that clearly indicate what went wrong
 - Avoid catch-all exception handlers that hide the root cause
-- No fallbacks unless I explicitly ask for them; fix root causes instead of masking symptoms, and make code either succeed or fail with a clear error
+- No fallbacks, symptom-masking guards, or silent recovery unless I explicitly ask for them; fix root causes and make code either succeed or fail with a clear error
 - External API or service calls: use retries with warnings, then raise the last error
 - Error messages must be clear, actionable, and specific: explain what failed and why, include request params, response body, status codes, and avoid generic "something went wrong"
 - Logging should use structured fields instead of interpolating dynamic values into message strings
 
 ## Libraries and Dependencies
 
-- Use modern package management files like `pyproject.toml` and `package.json`; install dependencies in project environments, not globally
+- Use modern stable, project-compatible package management, libraries, and language standards; prefer vendor-recommended patterns such as ESM when supported
+- Install dependencies in project environments, not globally
 - Add or update dependencies in project config files, not as one-off manual installs
 - If a dependency is installed locally, read its source code when needed instead of guessing, even if it is gitignored
 
 ## Testing
 
-- Respect the current repository testing strategy and existing test suite
-- Do not add new unit tests by default
-- When tests are needed, prefer integration, end-to-end, or smoke tests that validate real behavior
-- Use unit tests only rarely, mainly for stable datasets or pure data transformations
-- Never add unit tests just to increase coverage numbers
-- Avoid mocks when real calls are practical
-- It is usually better to spend a little money on real API or service calls than to maintain fragile mock-based coverage
-- Add only the minimum test coverage needed for the requested change
+- Respect the repository test strategy and add only the minimum useful tests for the requested change
+- Prefer smoke, integration, and end-to-end tests over narrow unit or regression tests; do not test static text, prompts, or config unless behavior depends on them
+- Do not create fake/mock-based tests by default; use real integrations when practical, even if they cost a little money
+- UI tests and automations must use stable IDs, test IDs, or accessibility IDs instead of visible text, and fail fast without fallback clicks
 
 ## Terminal Usage
 
@@ -94,6 +91,7 @@ Cursor IDE 现在有三层规则：
 - Read the existing code and relevant project instructions before editing
 - Keep changes minimal and tightly scoped to the current request: make the smallest useful diff, change only the lines needed to solve the problem, and avoid unrelated improvements unless the user asks for them
 - Match the existing style of the repository even if it differs from my personal preference; new code must look like it was written by the same author
+- Keep files small and cohesive; split by feature or responsibility when the project has no established structure
 - Do not revert unrelated changes
 - If you are unsure, inspect the codebase instead of inventing patterns
 - When project instructions include test or lint commands, run them before finishing if the task changed code
@@ -101,7 +99,7 @@ Cursor IDE 现在有三层规则：
 ## Documentation
 
 - Code is the primary documentation - use clear naming, types, and docstrings
-- Keep documentation in docstrings of the functions or classes they describe, not in separate files
+- Keep documentation in docstrings of the functions, classes, or modules they describe, not in separate files
 - Separate docs files only when a concept cannot be expressed clearly in code, and only one file per topic
 - Never duplicate documentation across files; reference other sources instead
 - Store knowledge as current state, not as a changelog of modifications


### PR DESCRIPTION
## What changed

- Updated the synchronized global LLM rules block across Cursor, Claude Code, and Codex articles in every language.
- Folded in approved guidance for native/vendor-recommended solutions, runtime validation of external data, stricter no-fallback/root-cause wording, modern stable dependency patterns, real-behavior testing, stable UI automation IDs, small cohesive files, and module docstrings.
- Kept all 15 copies byte-identical.

## Validation

- Passed: `git --no-pager diff --check`.
- Passed: local hash check found 15 blocks with 1 unique SHA-256 hash.
- Blocked: `npm run validate-metadata` failed because dependencies are not installed (`Cannot find module chalk`).
- Not retried: `npm ci` previously failed in this worktree because the local disk ran out of space (`ENOSPC`).

## Notes

This PR only changes the reusable rules block in article content.