### PR TITLE
Render homepage role title inline

### DIFF
--- a/src/components/PersonalInfo/PersonalInfo.module.css
+++ b/src/components/PersonalInfo/PersonalInfo.module.css
@@ -536,17 +536,7 @@
   font-style: normal;
   font-weight: 400;
   line-height: 98.99%;
-}
-
-.secondaryTitle {
-  text-transform: uppercase;
-  margin-bottom: 2px;
-  margin-top: 2px;
-  font-size: 1.2rem;
-  color: #232323;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 98.99%;
+  white-space: nowrap;
 }
 
 .contactButtonsContainer {
@@ -578,6 +568,10 @@
 
   .personalTitles {
     text-align: left;
+  }
+
+  .mainTitle {
+    white-space: normal;
   }
 
   .contactButtonsContainer {

--- a/src/components/PersonalInfo/PersonalInfo.tsx
+++ b/src/components/PersonalInfo/PersonalInfo.tsx
@@ -90,8 +90,9 @@ const PersonalInfo: React.FC<PersonalInfoProps> = ({
             />
           </div>
           <div className={styles.personalTitles}>
-            <p className={styles.mainTitle}>{personalInfoTranslations.jobTitle}</p>
-            <p className={styles.secondaryTitle}>{personalInfoTranslations.secondaryTitle}</p>
+            <p className={styles.mainTitle}>
+              {personalInfoTranslations.jobTitle}, {personalInfoTranslations.secondaryTitle}
+            </p>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- render the homepage role title as a single comma-separated line
- keep the same title styling for both parts
- remove the now-unused secondary title style in the PersonalInfo component

## Validation
- npm run lint