### PR TITLE
Allow homepage role title wrapping

### DIFF
--- a/src/components/PersonalInfo/PersonalInfo.module.css
+++ b/src/components/PersonalInfo/PersonalInfo.module.css
@@ -536,7 +536,6 @@
   font-style: normal;
   font-weight: 400;
   line-height: 98.99%;
-  white-space: nowrap;
 }
 
 .contactButtonsContainer {
@@ -568,10 +567,6 @@
 
   .personalTitles {
     text-align: left;
-  }
-
-  .mainTitle {
-    white-space: normal;
   }
 
   .contactButtonsContainer {


### PR DESCRIPTION
## Summary
- remove the nowrap rule from the homepage role title
- let the comma-separated title wrap naturally within its container

## Validation
- npm run lint