### PR TITLE
Filter object-shaped non-Error promise rejections in Sentry

### DIFF
--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -48,6 +48,10 @@ const IGNORED_CLIENT_ERROR_MESSAGES: readonly string[] = [
   'Load failed',
   // Non-Error promise rejections (usually from third-party scripts)
   'Non-Error promise rejection captured',
+  // Object/ErrorEvent rejections — Sentry SDK eventbuilder wording
+  // ("Object captured as promise rejection with keys: ..."); covers crypto-wallet
+  // and other browser-extension providers that reject with a plain object.
+  'captured as promise rejection',
 ];
 
 function getObjectStringField(value: object, fieldName: string): string | null {


### PR DESCRIPTION
Browser-extension wallet providers reject with plain {code, message} objects. The Sentry SDK serializes those as "Object captured as promise rejection with keys: ...", which the existing primitive-reason ignore entry ("Non-Error promise rejection captured") does not match, so the noise reaches Sentry. Add the object/ErrorEvent wording to the client beforeSend ignore list so this third-party noise is dropped. Matches via the existing exc.value check; no other logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)